### PR TITLE
fix: 모달창 안열림 이슈 해결

### DIFF
--- a/src/components/common/FloatingButtons.tsx
+++ b/src/components/common/FloatingButtons.tsx
@@ -51,9 +51,7 @@ export default function FloatingButtons() {
 
   const handleStudyCreate = () => {
     if(!session){
-      <LoginModal
-        isOpen={isModalOpen}
-        onClose={handleModalClose} />
+      setIsModalOpen(true);
     } else {
       router.push('/study/create')
     }
@@ -99,6 +97,10 @@ export default function FloatingButtons() {
           </button>
         )
       }
+      <LoginModal
+        isOpen={isModalOpen}
+        onClose={handleModalClose}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## 🐛 버그 수정

### 📋 버그 요약
- 비로그인상태일 때 스터디 만들기 버튼 클릭 시 아무 이벤트 발생하지 않음

### 📝 문제 상황
1. 세션이 없는 상황에서 모달을 직접 렌더링하려고 해서 문제 발생

**예상 동작:**
- 세션이 없을 때(비로그인) 스터디 버튼 클릭시 로그인 모달창 뜸

**실제 동작:**
- 아무런 이벤트 발생하지 않음

### 🔧 해결 방법
**근본 원인:**
- 모달 컴포넌트를 직접 렌더링하려고해서 발생한 문제

**적용 해결책:**
- 모달 open의 상태를 변경하여 열리도록함

### ✅ 테스트 결과
- [ ] 비로그인시 스터디만들기 버튼을 누르면 로그인 모달창 뜸 

### 🔗 관련 이슈
- Fixes #26 