### PR TITLE
fix: 비회원 스터디생성 접근 금지, 스터디카드 제목길이 수정

### DIFF
--- a/src/app/study/create/page.tsx
+++ b/src/app/study/create/page.tsx
@@ -1,6 +1,17 @@
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import StudyForm from "@/components/study/create/StudyForm";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 
-export default function Page(){
+export default async function Page(){
+
+  // 로그아웃 후 접근 불가
+  const session = await getServerSession(authOptions);
+
+  if(!session){
+    redirect("/");
+  }
+
   return(
     <main className="w-full min-h-screen flex justify-center">
       <div className="w-full max-w-5xl mb-12 p-4 space-y-12">

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
   const handleLogout = async () => {
     await signOut({redirect: false}); // NextAuth 로그 아웃
     toast.success("로그아웃 되었습니다", { duration: 2000});
-    router.push('/');
+    router.replace('/');
   }
 
   // 로그인 성공 핸들러

--- a/src/components/common/StudyCard.tsx
+++ b/src/components/common/StudyCard.tsx
@@ -53,7 +53,7 @@ export default function StudyCard({
   }
 
   return (
-    <div className="flex flex-col gap-4 w-full h-full cursor-pointer">
+    <div className="flex flex-col justify-between w-full h-full cursor-pointer">
       <div className={`
             flex flex-col gap-4 w-full h-full p-4 border border-gray-300 shadow-lg rounded-lg
             ${style.isDisabled ? "bg-gray-100 opacity-60" : "bg-white"}
@@ -64,10 +64,10 @@ export default function StudyCard({
           <span className="bg-primary-500 text-white px-2 ">{name}</span>
           {style.canDelete && <X className="ml-auto" />}
         </div>
-        <p className="headline3 text-primary-700 mb-2">{title}</p>
+        <p className="headline3 text-primary-700 mb-2 line-clamp-2">{title}</p>
         <div className="pb-4">
           <p className="body-m">{`${formatDate(startDate)} - ${formatDate(endDate)}`}</p>
-          <p>{time}</p>
+          <p>{time} ~</p>
           <div className="flex items-center gap-2 text-gray-500">
             <User size={20} />
             <span>{currentMembers}/{maxMembers}</span>
@@ -75,11 +75,6 @@ export default function StudyCard({
         </div>
         <div className="flex">
           <span className="border border-primary-100 text-primary-500 px-3 rounded-full self-center">#{tag}</span>
-          {/* <span className={`px-3 rounded-full ml-auto self-center
-            ${isRecruiting ? "bg-primary-50 text-primary-500" : "bg-gray-300 text-gray-700"}`}>
-              {isRecruiting ? "모집중" : "모집마감"}
-          </span> */}
-          
           {(variant === "mainOpen" || variant === "mainClosed") && (
             <span className={`px-3 rounded-full ml-auto self-center 
               ${isRecruiting ? "bg-primary-50 text-primary-500" : "bg-gray-300 text-gray-700"}`}>

--- a/src/components/main/Carousel.tsx
+++ b/src/components/main/Carousel.tsx
@@ -5,7 +5,9 @@ import Image from 'next/image';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Autoplay, Navigation } from 'swiper/modules';
 import 'swiper/css';
-import Link from 'next/link';
+import { useSession } from 'next-auth/react';
+import LoginModal from '../common/LoginModal';
+import { useRouter } from 'next/navigation';
 
 interface Slide {
   id: number
@@ -16,8 +18,11 @@ interface Slide {
 }
 
 export default function Carousel() {
+  const {data: session} = useSession();
+  const router = useRouter();
   // 모바일 고려
   const [isMobile, setIsMobile] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const slides: Slide[] = [
     {
@@ -42,43 +47,50 @@ export default function Carousel() {
     return () => window.removeEventListener('resize', handleResize);
   },[]);
 
-  return(
-    <div className='rounded-2xl overflow-hidden'>
-      <Swiper
-        modules={[Autoplay, Navigation]}
-        loop={true}
-        autoplay={{
-          delay:5000,
-          disableOnInteraction: false
-        }}
-        navigation={{
-          nextEl: '.swiper-button-next'
-          }}>
+  // 로그인 안된 사용자
+  const handleSlideClick = (link?: string) => {
+    if(!link) return;
+    if(!session) {
+      setIsModalOpen(true);
+    } else {
+      router.push(link);
+    }
+  }
 
-        { slides.map((slide) => (
+  return(
+    <>
+      <div className='rounded-2xl overflow-hidden'>
+        <Swiper
+          modules={[Autoplay, Navigation]}
+          loop={true}
+          autoplay={{ delay:5000, disableOnInteraction:false }}
+          navigation={{ nextEl: '.swiper-button-next' }}
+          preventClicks={false}      // 클릭이 막히지 않도록
+          preventClicksPropagation={false}
+        >
+        {slides.map(slide => (
           <SwiperSlide key={slide.id}>
-           { slide.link? (
-            <Link href={slide.link}>
-              <Image 
-                src={isMobile? slide.mobile : slide.desktop}
+            <div
+              onClick={() => handleSlideClick(slide.link)}
+              className="cursor-pointer"
+            >
+              <Image
+                src={isMobile ? slide.mobile : slide.desktop}
                 alt={slide.alt}
                 width={1280}
                 height={330}
                 className="w-full h-auto"
-                priority={slide.id===1} />
-            </Link>
-           ) : (
-            <Image
-              src={isMobile? slide.mobile : slide.desktop}
-              alt={slide.alt}
-              width={1280}
-              height={330}
-              className="w-full h-auto"
-              priority={slide.id===1} />
-           )}
+                priority={slide.id===1}
+              />
+            </div>
           </SwiperSlide>
-        ))}    
-      </Swiper>
-    </div>
+        ))}
+        </Swiper>
+      </div>
+      <LoginModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        />
+    </>
   )
 }


### PR DESCRIPTION
## 🐛 버그 수정

### 📝 문제 상황
- 회원이 아니여도 스터디생성 페이지 접근 가능
- 스터디 제목이 너무 길어도 스터디카드에 전부 노출

### 📋 수정 사항
- 회원이 아닌경우 해당 캐러셀 클릭 시 로그인 모달뜨도록 처리함
- 로그아웃 후 뒤로가기로 스터디생성 페이지 접근 시 메인페이지로 이동되도록 라우팅 처리함
- 스터디카드에서 제목은 2줄까지만 보이도록 처리함