### PR TITLE
fix: 스터디멤버는 상세페이지에서 바로 입장가능

### DIFF
--- a/src/components/study/about/BackButton.tsx
+++ b/src/components/study/about/BackButton.tsx
@@ -1,10 +1,17 @@
 'use client'
 import { ChevronLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function BackButton() {
   const router = useRouter();
-  const prevPath = sessionStorage.getItem('prevPath') || '';
+  const [prevPath, setPrevPath] = useState<string>("");
+  
+  useEffect(() => {
+    const path = sessionStorage.getItem('prevPath') || "";
+    setPrevPath(path);
+  },[]);
+  
   const handleBack = () => {
     if(prevPath.includes("study/create")){
       // 세션정리

--- a/src/components/study/about/JoinButton.tsx
+++ b/src/components/study/about/JoinButton.tsx
@@ -40,20 +40,18 @@ export default function JoinButton({
 
   const userId = session?.user?.id;
 
-  // 본인 작성 글
-  if(userId && userId === creatorId){
-    return null;
-  }
+  // 작성자
+  const isCreator = userId === creatorId;
 
+  // 참여 완료
   const hasApplied = applicants.some(
     (applicant) => applicant.userId === userId
   );
 
+  // 스터디 멤버
   const isMember = members.some(
     (member) => member.userId === userId
   );
-
-  const disabled = hasApplied || isMember;
 
 
   const handleConfirm = async (formData: {introduction: string}) => {
@@ -91,12 +89,14 @@ export default function JoinButton({
     <Button 
       size="lg"
       className="px-12"
-      disabled={disabled}
-      variant={disabled ? "disabled" : "primary"}
+      disabled={hasApplied}
+      variant={hasApplied ? "disabled" : "primary"}
       onClick={() => {
         if(!userId){
           setIsLoginModalOpen(true); // 로그인 X : 로그인 모달
-        } else if(!disabled){
+        } else if(isMember || isCreator) {
+          router.push(`/study/${studyId}`);
+        } else if(!hasApplied){
           setIsModalOpen(true)       // 참여 X : 참여 모달
         }
       }}>
@@ -104,8 +104,8 @@ export default function JoinButton({
         ? "참여하기"
         : hasApplied
         ? "승인대기"
-        : isMember
-        ? "참여완료"
+        : isMember || isCreator
+        ? "스터디 입장하기"
         : "참여하기"  
       }
     </Button>


### PR DESCRIPTION
## 🐛 버그 수정

### 📌 변경 사항
- 기존: 스터디 작성자는 참여버튼 안뜸, 스터디 멤버는 [참여완료] 버튼 뜸
- 변경: 스터디의 모든 멤버한테는 [스터디 입장하기] 버튼으로 스터디 입장 가능하도록 변경