### PR TITLE
fix: 스터디생성 페이지 이슈

### DIFF
--- a/src/components/study/create/StudyForm.tsx
+++ b/src/components/study/create/StudyForm.tsx
@@ -10,7 +10,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { usePathname, useRouter } from "next/navigation";
 import toast from "react-hot-toast";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AlertModal from "@/components/common/AlertModal";
 
 type FormData = z.infer<typeof studyFormSchema>;
@@ -19,20 +19,37 @@ interface StudyFormProps {
   defaultValues?: Partial<FormData>;
 }
 
+// localstorage 저장
+const savedDataKey = "studyFormData";
+
 export default function StudyForm({defaultValues}: StudyFormProps) {
+  const saved = typeof window !== "undefined" ? localStorage.getItem(savedDataKey) : null;
+  const parsed = saved ? JSON.parse(saved) : {};
   const {
     register, 
     handleSubmit, 
     control, 
     watch,
+    reset,
     formState: {errors, isDirty}
   } = useForm<FormData>({
     resolver: zodResolver(studyFormSchema),
     defaultValues:{
       weekdays: [],
       ...defaultValues,
+      ...parsed,
     }
   });
+
+  useEffect(() => {
+    const subscription = watch((value) => {
+      // 입력값 로컬스토리지에 저장
+      localStorage.setItem(savedDataKey, JSON.stringify(value));
+    });
+
+    // cleanup
+    return () => subscription.unsubscribe();
+  }, [watch])
 
   const router = useRouter();
   const pathname = usePathname();
@@ -41,6 +58,8 @@ export default function StudyForm({defaultValues}: StudyFormProps) {
 
   const handleConfirm = () => {
     if(isEdit){
+      // 취소 시 데이터 삭제
+      localStorage.removeItem(savedDataKey);
       router.push(`/study/${pathname.split("/")[2]}/about`); // 상세페이지로 이동
     } else {
       router.push('/'); // 메인페이지로 이동
@@ -71,6 +90,8 @@ export default function StudyForm({defaultValues}: StudyFormProps) {
         setTimeout(() => {
           router.push(`/study/${result.studyId || pathname.split("/")[2]}/about`);
         }, 1500);
+        // 제출 시 삭제
+        localStorage.removeItem(savedDataKey);
       } else {
         alert(result.error || "오류가 발생했습니다");
       }
@@ -133,7 +154,7 @@ export default function StudyForm({defaultValues}: StudyFormProps) {
         title={isEdit? "글 수정을 취소하시겠습니까?" : "글 작성을 취소하시겠습니까?"}
         subtitle="작성중인 내용은 저장되지 않습니다"
         onConfirm={handleConfirm}
-        />
+      />
     </>
   )
 }

--- a/src/components/study/create/StudyForm.tsx
+++ b/src/components/study/create/StudyForm.tsx
@@ -25,7 +25,7 @@ export default function StudyForm({defaultValues}: StudyFormProps) {
     handleSubmit, 
     control, 
     watch,
-    formState: {errors}
+    formState: {errors, isDirty}
   } = useForm<FormData>({
     resolver: zodResolver(studyFormSchema),
     defaultValues:{
@@ -117,8 +117,10 @@ export default function StudyForm({defaultValues}: StudyFormProps) {
               취소
             </Button>
             <Button size="md"
+                    variant={!isDirty ? "disabled" : "primary"}
                     className="w-full"
                     type="submit"
+                    disabled={!isDirty}
                     >
               { isEdit ? "수정" : "등록"}
             </Button>    

--- a/src/lib/validation/studyFormSchema.ts
+++ b/src/lib/validation/studyFormSchema.ts
@@ -34,11 +34,27 @@ export const studyFormSchema = z.object({
   const startTime = values.startTime;
   const endTime = values.endTime;
 
-  if(startTime && endTime && startTime>=endTime){
-    ctx.addIssue({
-      code: "custom",
-      path: ["endTime"],
-      message: "종료시간은 시작시간 이후여야합니다"
-    })
+  if(startTime && endTime){
+    const [startH, startM] = startTime.split(":").map(Number);
+    const [endH, endM] = endTime.split(":").map(Number);
+
+    const startTotal = startH * 60 + startM;
+    const endTotal = endH * 60 + endM;
+
+    const diffMinutes = endTotal - startTotal;
+    
+    if(diffMinutes <= 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["endTime"],
+        message: "종료시간은 시작시간 이후로 가능합니다"
+      })
+    } else if (diffMinutes < 30){
+      ctx.addIssue({
+        code: "custom",
+        path: ["endTime"],
+        message: "스터디 최소 시간은 30분입니다"
+      })
+    }
   }
-})
+});


### PR DESCRIPTION
## 🐛 버그 수정

### 📌 변경 사항
- 스터디 최소시간 30분으로 설정
- 수정필드 하나라도 있을 때만 수정 가능
- 스터디 생성/수정 중 새로고침 시 내용 저장

### ✅ 테스트해야 할 부분
- [ ]  스터디 생성 시 자동저장으로 변경하고 스터디 요일 선택 시 바로 반영안되는 이슈
- [ ] 스터디 생성중 새로고침시 그전의 내용이 기준이되어 수정 버튼이 비활성화됨